### PR TITLE
chore(docker): add build-tools dependency

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,7 +13,9 @@ COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-dev
 
 RUN apt-get update && \
-    apt-get install -y openjdk-21-jdk && \
+    apt-get install -y \
+    openjdk-21-jdk \
+    build-essential && \
     rm -rf /var/lib/apt/lists/*
 
 COPY generate_api.sh /generate_api.sh


### PR DESCRIPTION
```
      g++ -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall -fPIC -I./python -I./lib -I./deps/double-conversion/double-conversion -I/usr/local/include/python3.12 -c ./deps/double-conversion/double-conversion/bignum-dtoa.cc -o build/temp.linux-x86_64-cpython-312/deps/double-conversion/double-conversion/bignum-dtoa.o -D_GNU_SOURCE
      error: command 'g++' failed: No such file or directory
      [end of output]
```